### PR TITLE
12/10: bfs traversal and scaled ratings

### DIFF
--- a/entry/main.cpp
+++ b/entry/main.cpp
@@ -18,4 +18,18 @@ int main() {
     cout << adj_mat.getRating(113, 7369) << endl; // -1
     cout << adj_mat.getRating(3450, 97) << endl; // 5
     cout << adj_mat.getRating(14, 3450) << endl; //1
+
+    // 1(-1) + 11 = 10
+    // 1(-1) + 11 = 10
+    // -1(-1) + 11 = 12
+    // 5(-1) + 11 = 6
+    // 1(-1) + 11 = 10
+    
+    // ratings correctly scaled so that negative ratings have higher weight and greater ratings (5 to 6) have lower weight than lesser ratings (1 to 10)
+
+    vector<int> path = adj_mat.bfs(3450);
+    for (auto i : path) {
+        cout << i << "->";
+    }
+    cout << endl;
 }

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -58,10 +58,16 @@ Graph::Graph(const string& filename) {
             str_stream >> RATING;
             str_stream.ignore();
             str_stream >> TIME;
-            // cout << SOURCE << ", " << TARGET << ", " << RATING << ", " << TIME << endl;
-            // put rating in adjacency matrix
+            // so that negative ratings are weighted higher
+            RATING = RATING * -1;
+            // so that ratings go from 1 to 21 since 0 represents no rating
+            RATING = RATING + 11;
+            // now a rating of -10 is 21, having the greatest weight, and a rating of 10 is 1, having the least weight
+            // thus, the path with the greatest distance will be the least reliable transaction path
             cout << "insert " << RATING << " into [" << SOURCE << "][" << TARGET << "]" << endl;
             adj_matrix[SOURCE][TARGET] = RATING;
+
+
         }
     }
     input.close();
@@ -118,4 +124,28 @@ int Graph::minDistance(vector<int> distance, vector<bool> incShort) const {
 
 const vector<vector<int>>& Graph::getMatrix() const {
     return adj_matrix;
+}
+
+vector<int> Graph::bfs(int src) {
+    vector<int> path;
+    vector<bool> visited;
+    for (int i=0; i<7604; i++) {
+        visited.push_back(false);
+    }
+    queue<int> q;
+    q.push(src);
+    visited[src] = true;
+
+    while (!q.empty()) {
+        int curr = q.front();
+        path.push_back(curr);
+        q.pop();
+        for (int target=0; target<(int)adj_matrix[curr].size(); target++) {
+            if (adj_matrix[curr][target] >= 1 && visited[target]==false) {
+                q.push(target);
+                visited[target] = true;
+            }
+        }
+    }
+    return path;
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <map>
 #include <bits/stdc++.h>
+#include <queue>
 
 using namespace std;
 class Graph {
@@ -16,6 +17,7 @@ class Graph {
 		const vector<vector<int>>& getMatrix() const;
 		void print();
 		int getRating(int src, int target);
+		vector<int> bfs(int src);
 	private:
 		int minDistance(vector<int> distance, vector<bool> incShort) const;
 


### PR DESCRIPTION
added bfs traversal which returns a vector containing the traversal starting from src node id. scaled the ratings originally from -10 to 10 to ratings from 1 to 21 by multiplying by -1 and adding 11. The worse the rating the greater the weight of the edge.