### PR TITLE
12/10: added trust func following project proposal

### DIFF
--- a/entry/main.cpp
+++ b/entry/main.cpp
@@ -32,4 +32,17 @@ int main() {
         cout << i << "->";
     }
     cout << endl;
+
+    cout << "dist: " << adj_mat.dijkstra(3450, 2665) << endl;
+    cout << "dist: " << adj_mat.dijkstra(3450, 1944) << endl;
+    cout << "dist: " << adj_mat.dijkstra(3450, 807) << endl;
+    cout << "dist: " << adj_mat.dijkstra(3450, 1849) << endl;
+    cout << "dist: " << adj_mat.dijkstra(3450, 1014) << endl;
+
+    // returns rating immediately if there is already rating between users
+    // otherwise returns distance between users, with shorter distances representing more trustworthy transcation paths
+    // a large number could also represent longer transaction paths, but we assume the longer the transaction path, the reliablity falls.
+    cout << "trust: " << adj_mat.trust(3450, 2665) << endl; // 61 since dijkstra runs
+    cout << "trust: " << adj_mat.trust(3450, 97) << endl; // 6 since rating already exists between two users
+
 }

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -141,11 +141,18 @@ vector<int> Graph::bfs(int src) {
         path.push_back(curr);
         q.pop();
         for (int target=0; target<(int)adj_matrix[curr].size(); target++) {
-            if (adj_matrix[curr][target] >= 1 && visited[target]==false) {
+            if (adj_matrix[curr][target] > 0 && visited[target]==false) {
                 q.push(target);
                 visited[target] = true;
             }
         }
     }
     return path;
+}
+
+int Graph::trust(int src, int target) {
+    if (adj_matrix[src][target] > 0) {
+        return adj_matrix[src][target];
+    }
+    return dijkstra(src, target);
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -18,6 +18,7 @@ class Graph {
 		void print();
 		int getRating(int src, int target);
 		vector<int> bfs(int src);
+		int trust(int src, int target);
 	private:
 		int minDistance(vector<int> distance, vector<bool> incShort) const;
 


### PR DESCRIPTION
function returns rating if rating exists between two users, otherwise it uses dijkstras to determine the distance between the two users. since the weight of edges represent rating, with greater weights being worse, the greater the distance the worse the transaction path between two users. it could also just be a long transaction path between the users with good ratings along the path, but we arbitrarily prioritized shorter transaction paths as more reliable in our project proposal.